### PR TITLE
Allow newer solidity versions (up to <0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Broaden the Solidity version pragma to ^0.4.21
 
 ### Added
 - [README]: EIP badge with link to the official EIP

--- a/contracts/ERC20Token.sol
+++ b/contracts/ERC20Token.sol
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-pragma solidity 0.4.21;
+// solhint-disable-next-line compiler-fixed
+pragma solidity ^0.4.21;
 
 
 interface ERC20Token {

--- a/contracts/ERC777Token.sol
+++ b/contracts/ERC777Token.sol
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-pragma solidity 0.4.21;
+// solhint-disable-next-line compiler-fixed
+pragma solidity ^0.4.21;
 
 
 interface ERC777Token {

--- a/contracts/ERC777TokensRecipient.sol
+++ b/contracts/ERC777TokensRecipient.sol
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-pragma solidity 0.4.21;
+// solhint-disable-next-line compiler-fixed
+pragma solidity ^0.4.21;
 
 
 interface ERC777TokensRecipient {

--- a/contracts/ERC777TokensSender.sol
+++ b/contracts/ERC777TokensSender.sol
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-pragma solidity 0.4.21;
+// solhint-disable-next-line compiler-fixed
+pragma solidity ^0.4.21;
 
 
 interface ERC777TokensSender {


### PR DESCRIPTION
The solidity version pragma currently used forbids versions other than 0.4.21, even though the code works fine (with some warnings) on newer language versions. This prevents contracts working with newer language versions from importing the ERC777 contracts (interfaces). In order to allow use with newer language versions this broadens the constraint to `^0.4.21` from `0.4.21`.

The solhint `compiler-fixed` rule is disabled for the pragma line in library/interface definitions per [ConsenSys guidelines](https://consensys.github.io/smart-contract-best-practices/recommendations/#lock-pragmas-to-specific-compiler-version).