### PR TITLE
Fully implements ERC777

### DIFF
--- a/contracts/ERC777BaseToken.sol
+++ b/contracts/ERC777BaseToken.sol
@@ -71,8 +71,16 @@ contract ERC777BaseToken is ERC777Token, ERC820Implementer {
     /// @notice Send `_amount` of tokens to address `_to` passing `_data` to the recipient
     /// @param _to The address of the recipient
     /// @param _amount The number of tokens to be sent
+    /// @para, _data The data to be sent
     function send(address _to, uint256 _amount, bytes _data) public {
         doSend(msg.sender, msg.sender, _to, _amount, _data, "", true);
+    }
+    
+    /// @notice Send `_amount` of tokens to address `_to` passing `_data` to the recipient
+    /// @param _to The address of the recipient
+    /// @param _amount The number of tokens to be sent
+    function send(address _to, uint256 _amount) public {
+        doSend(msg.sender, msg.sender, _to, _amount, "", "", true);
     }
 
     /// @notice Authorize a third party `_operator` to manage (send) `msg.sender`'s tokens.

--- a/contracts/ERC777BaseToken.sol
+++ b/contracts/ERC777BaseToken.sol
@@ -71,7 +71,7 @@ contract ERC777BaseToken is ERC777Token, ERC820Implementer {
     /// @notice Send `_amount` of tokens to address `_to` passing `_data` to the recipient
     /// @param _to The address of the recipient
     /// @param _amount The number of tokens to be sent
-    /// @para, _data The data to be sent
+    /// @param, _data The data to be sent
     function send(address _to, uint256 _amount, bytes _data) public {
         doSend(msg.sender, msg.sender, _to, _amount, _data, "", true);
     }


### PR DESCRIPTION
```
ERC777/contracts/ERC777Token.sol:14:5: Missing implementation:
    function send(address to, uint256 amount) public;
```
I have fixed this by implementing `function send(address to, uint256 amount` within `ERC777BaseToken.sol`